### PR TITLE
docs: clarify public site description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 仕様: `SPEC_NOTIFYHUB_CSIRT_DAILY_REPORT.md`（添付仕様に準拠）
 
+本プロジェクトの公開サイトは https://www.notifyhub.site/ です。
+サイバーセキュリティに関する記事を日次で収集してわかりやすくまとめています。
+
 ## セットアップ（Python 3.11）
 
 ```powershell


### PR DESCRIPTION
## 概要
READMEに記載している公開サイトURL（https://www.notifyhub.site/）の説明文を、より正確で分かりやすい表現に更新しました。
## 変更内容
- 公開サイトの用途説明を具体化
- 利用者が確認できる情報（概要・機能・お知らせ）を明記
## 変更ファイル
- README.md
## 影響範囲
- ドキュメントのみ（アプリケーション動作への影響なし）