### PR TITLE
docs: clarify README and add SWA auth config

### DIFF
--- a/site/staticwebapp.config.json
+++ b/site/staticwebapp.config.json
@@ -1,0 +1,14 @@
+{
+  "routes": [
+    { "route": "/login", "redirect": "/.auth/login/aad" },
+    { "route": "/logout", "redirect": "/.auth/logout" },
+
+    { "route": "/*", "allowedRoles": ["authenticated"] }
+  ],
+  "responseOverrides": {
+    "401": {
+      "redirect": "/login",
+      "statusCode": 302
+    }
+  }
+}


### PR DESCRIPTION
## 概要
READMEの公開サイト説明を明確化し、Azure Static Web Apps の認証ルーティング設定を追加しました。

## 変更内容
- READMEの公開サイト説明を、用途が分かる表現に更新
- SWA用の認証設定ファイルを追加（未認証ユーザーを /login へリダイレクト）

## 変更ファイル
- README.md
- site/staticwebapp.config.json

## 影響範囲
- ドキュメントおよびSWAのアクセス制御設定
- アプリ本体ロジックの変更なし

## 確認観点
- /login -> /.auth/login/aad へリダイレクトされること
- /logout -> /.auth/logout へリダイレクトされること
- 未認証時に保護ルートアクセスで /login へ遷移すること