### PR TITLE
Add deep dive lesson section to digest articles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python-envs.defaultEnvManager": "ms-python.python:system"
+    "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+    "python.pythonPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ python -m pip install -U pip
 pip install ".[dev]"
 ```
 
+- VS Code もこの `.venv` を使う前提です。ワークスペースを開いたまま作成した場合は `Developer: Reload Window` を実行し、必要なら Python インタープリタとして `.venv\Scripts\python.exe` を選択してください。
+- ターミナルで直接実行する場合も、未アクティブなら `.\.venv\Scripts\python.exe -m ...` の形で呼び出すと system Python を避けられます。
+
 ### 2) `.env` を作成
 
 ```powershell
@@ -39,6 +42,12 @@ Copy-Item .env.example .env
 
 ```powershell
 notifyhub-digest run --out-dir .\out
+```
+
+未アクティブのターミナルでは次でも同じです。
+
+```powershell
+.\.venv\Scripts\python.exe -m notifyhub_digest.cli run --out-dir .\out
 ```
 
 ### 4) 出力先

--- a/src/notifyhub_digest/models.py
+++ b/src/notifyhub_digest/models.py
@@ -57,9 +57,15 @@ class TechnicalTerm(BaseModel):
     explanation: str
 
 
+class Lesson(BaseModel):
+    title: str
+    body: str
+
+
 class AnalysisResult(BaseModel):
     summary_html: str = ""
     technical_terms: list[TechnicalTerm] = Field(default_factory=list)
+    lessons: list[Lesson] = Field(default_factory=list)
     impact_level: ImpactLevel = "Unknown"
     impact_reason: str = ""
     threat_type: ThreatType = "Unknown"

--- a/src/notifyhub_digest/openai_client.py
+++ b/src/notifyhub_digest/openai_client.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import httpx
 
-from notifyhub_digest.models import AnalysisResult
+from notifyhub_digest.models import AnalysisResult, Lesson
 
 
 logger = logging.getLogger(__name__)
@@ -62,29 +62,18 @@ SYSTEM_PROMPT = (
     "    - ただし観測が広域でも自組織に関係が薄い場合は据え置き/下げも可。\n"
     "- 補正を適用した根拠は impact_reason に必ず含める（例: 公的注意喚起/KEV、ベンダーパッチ済み、観測増加、メディア二次情報 など）。\n"
     "\n"
-    "『読む/流す/捨てる』フラグ判定ロジック（重要）:\n"
-    "- read_action を次の3値から必ず選び、CSIRTが次に取るべき扱いを示す:\n"
-    "  * Read（読む）: 即判断やアクションが必要/自組織影響が高い可能性/検知・封じ込め設計に直結\n"
-    "  * Pass（流す）: 参考情報として共有価値はあるが、即アクション不要（状況監視/次回判断材料）\n"
-    "  * Drop（捨てる）: 自組織への関連が薄い・重複・実務価値が低い\n"
-    "- 判定の具体基準（複合判断）:\n"
-    "  * Read を強く推奨:\n"
-    "    - impact_level が Critical/High\n"
-    "    - 既に悪用確認、KEV掲載、ゼロデイ/活発な攻撃波及、認証前RCEなど\n"
-    "    - 自組織で該当製品/クラウド/公開資産を使っている前提で影響が大きい\n"
-    "  * Pass を推奨:\n"
-    "    - Medium/Lowで、対策はあるが緊急性が低い\n"
-    "    - ベンダーの更新情報、運用ベストプラクティス、注意喚起（直接の攻撃波及は未確認）\n"
-    "  * Drop を推奨:\n"
-    "    - IT一般の話題でCSIRT業務への接続が薄い（セキュリティ示唆が小さい）\n"
-    "    - 既報の焼き直し、具体性のない憶測記事、対象がニッチで自組織に関係しにくい\n"
-    "- 判断根拠は action_reason に短く含める。\n"
-    "\n"
     "technical_terms（用語解説）ルール:\n"
     "- 同じ用語が過去にも使われていることを前提とし、毎回同じ説明を繰り返さない\n"
     "- 今回の記事文脈で『なぜ重要か』に焦点を当てる\n"
     "- 可能な限り対立概念・混同されやすい概念と対比して説明する\n"
     "- explanation は100文字以内、日本語2〜3文\n"
+    "\n"
+    "lessons（深掘り解説）ルール:\n"
+    "- 記事中の技術用語、製品情報、法令、制度などから最も学習価値が高いものを1つだけ選ぶ\n"
+    "- 技術的な本質を短く教える補助教材として書く。単なる用語の言い換えは禁止\n"
+    "- 3〜5分で理解できる分量を目安にし、具体例を必ず含める\n"
+    "- 同じ用語でも毎回切り口を固定せず、実装、処理フロー、運用上の注意、関連リスクなど記事文脈に最も合う軸を選ぶ\n"
+    "- 適切な題材が見当たらない場合は lessons に 1 件だけ title=なし, body=なし を入れる\n"
     "\n"
     "分析観点の指針:\n"
     "- 前提条件: 攻撃成立に必要な構成・権限・露出条件\n"
@@ -110,11 +99,10 @@ def _analysis_schema_hint() -> str:
         "{\n"
         '  \"summary_html\": \"<div>...</div>\",\n'
         '  \"technical_terms\": [{\"term\":\"...\",\"explanation\":\"...\"}],\n'
+        '  \"lessons\": [{\"title\":\"...\",\"body\":\"...\"}],\n'
         '  \"impact_level\": \"Critical|High|Medium|Low|Info\",\n'
         '  \"impact_reason\": \"...\",\n'
-        '  \"threat_type\": \"Vulnerability|Exploit|Zero-day|Vulnerability Disclosure|Patch|Misconfiguration|Malware|Ransomware|Botnet|Cryptojacking|Phishing|Business Email Compromise|Scam/Fraud|Credential Theft|Intrusion|Data Breach|DDoS|Supply Chain|Advisory|Other|Unknown\",\n'
-        '  \"read_action\": \"Read|Pass|Drop\",\n'
-        '  \"action_reason\": \"...\"\n'
+        '  \"threat_type\": \"Vulnerability|Exploit|Zero-day|Vulnerability Disclosure|Patch|Misconfiguration|Malware|Ransomware|Botnet|Cryptojacking|Phishing|Business Email Compromise|Scam/Fraud|Credential Theft|Intrusion|Data Breach|DDoS|Supply Chain|Advisory|Other|Unknown\"\n'
         "}\n"
         "\n"
         "summary_html 制約:\n"
@@ -122,32 +110,31 @@ def _analysis_schema_hint() -> str:
         "- 属性（class/id/style等）は付けない\n"
         "- 以下の構成を厳守:\n"
         "  <h4>概要</h4><p>...</p>\n"
-        "  <h4>判断ポイント</h4><ul><li>...</li></ul>\n"
-        "  <h4>対応アクション（今すぐ・継続）</h4><ul><li>...</li></ul>\n"
         "\n"
         "概要:\n"
         "- 4〜6文で記述し、記事理解のための文脈を厚めに書く\n"
         "- 最低でも以下を含める: 何が起きたか / どう悪用されるか / どこまで影響が広がるか / 未確認事項\n"
         "- 単なる出来事の言い換えではなく、判断に必要な背景を補う\n"
         "\n"
-        "判断ポイント / 対応アクション（今すぐ・継続）:\n"
-        "- それぞれ最大3項目まで\n"
-        "- 判断ポイント: 根拠・前提条件・優先度の理由のみ（具体作業は書かない）\n"
-        "- 対応アクション: 実施タスクのみ（抽象論は書かない）\n"
-        "- 対応アクションの各項目は先頭に [今すぐ] または [継続] を付ける\n"
-        "\n"
         "強調ルール:\n"
         "- 意思決定に影響する語句のみ <strong>…</strong> で強調\n"
         "- 最大8箇所、短いフレーズ単位\n"
         "\n"
         "文字量:\n"
-        "- summary_html 全体で900〜1200文字程度\n"
+        "- summary_html 全体で500〜800文字程度\n"
         "\n"
         "technical_terms 制約:\n"
         "- 最大4件\n"
         "- explanation は100文字以内、2〜3文\n"
         "- 対立概念・混同されやすい概念があれば必ず対比\n"
         "- 一般名詞・単なる固有名詞の列挙は禁止\n"
+        "\n"
+        "lessons 制約:\n"
+        "- 0〜1件ではなく、常に1件入れる\n"
+        "- 学習価値の高い題材がある場合は title/body を埋める\n"
+        "- 題材が弱い場合は title=なし, body=なし とする\n"
+        "- body は3〜5分で読み切れる長さで、少なくとも1つ具体例を含める\n"
+        "- 記事内容の焼き直しではなく、背景理解や実務判断に効く説明を書く\n"
         "\n"
         "term 表記:\n"
         "- 英語が一般的な場合は英語→日本語併記\n"
@@ -158,10 +145,6 @@ def _analysis_schema_hint() -> str:
         "impact_reason:\n"
         "- impact_level の根拠を2〜3行で簡潔に\n"
         "- 技術的深刻度 + 運用影響 + 情報源補正の根拠\n"
-        "\n"
-        "read_action / action_reason:\n"
-        "- read_action は Read|Pass|Drop のいずれか\n"
-        "- action_reason に短く根拠（緊急性/自組織関連/二次情報/重複など）\n"
         "\n"
         "threat_type:\n"
         "- 複数該当しそうな場合は、CSIRTが最初に意識すべき1種を選択\n"
@@ -273,7 +256,7 @@ def _coerce_analysis_result(parsed: dict[str, Any]) -> AnalysisResult:
     """Be tolerant to minor schema drift and fill defaults."""
 
     if not isinstance(parsed, dict):
-        return AnalysisResult(summary_html="", technical_terms=[], impact_level="Unknown", impact_reason="", threat_type="Unknown")
+        return AnalysisResult(summary_html="", technical_terms=[], lessons=[], impact_level="Unknown", impact_reason="", threat_type="Unknown")
 
     def _normalize_threat_type(raw: str) -> str:
         v = (raw or "").strip()
@@ -389,6 +372,29 @@ def _coerce_analysis_result(parsed: dict[str, Any]) -> AnalysisResult:
     if "threat_type" in parsed and isinstance(parsed["threat_type"], str):
         parsed["threat_type"] = _normalize_threat_type(parsed["threat_type"])
 
+    raw_lessons = parsed.get("lessons")
+    if isinstance(raw_lessons, list):
+        normalized_lessons: list[dict[str, str]] = []
+        for entry in raw_lessons[:1]:
+            if not isinstance(entry, dict):
+                continue
+            title = str(entry.get("title") or "").strip()
+            body = str(entry.get("body") or "").strip()
+            if not title and not body:
+                continue
+            if not title:
+                title = "なし" if body == "なし" else "補足"
+            if not body:
+                body = "なし" if title == "なし" else "説明なし"
+            normalized_lessons.append({"title": title, "body": body})
+        parsed["lessons"] = normalized_lessons
+    elif isinstance(raw_lessons, dict):
+        title = str(raw_lessons.get("title") or "").strip() or "補足"
+        body = str(raw_lessons.get("body") or "").strip() or "説明なし"
+        parsed["lessons"] = [{"title": title, "body": body}]
+    else:
+        parsed["lessons"] = []
+
     try:
         return AnalysisResult.model_validate(parsed)
     except Exception:
@@ -396,6 +402,7 @@ def _coerce_analysis_result(parsed: dict[str, Any]) -> AnalysisResult:
         return AnalysisResult(
             summary_html=str(parsed.get("summary_html") or ""),
             technical_terms=[],
+            lessons=[Lesson(title="なし", body="なし")],
             impact_level=str(parsed.get("impact_level") or "Unknown"),
             impact_reason=str(parsed.get("impact_reason") or ""),
             threat_type=_normalize_threat_type(str(parsed.get("threat_type") or "")),
@@ -504,6 +511,7 @@ def analyze_item(
         return AnalysisResult(
             summary_html=_fallback_summary_html(summary),
             technical_terms=[],
+            lessons=[Lesson(title="なし", body="なし")],
             impact_level="Unknown",
             impact_reason="",
             threat_type="Unknown",

--- a/src/notifyhub_digest/render.py
+++ b/src/notifyhub_digest/render.py
@@ -4,7 +4,7 @@ import html
 import json
 import re
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -56,6 +56,31 @@ def _term_cards_html(item: FeedItem) -> str:
                     '<div class="termCard">',
                     f'  <div class="term">{term}</div>',
                     f'  <p class="exp">{exp}</p>',
+                    "</div>",
+                ]
+            )
+        )
+    return "\n".join(parts)
+
+
+def _lesson_cards_html(item: FeedItem) -> str:
+    lessons = item.analysis.lessons or []
+    if not lessons:
+        lessons = [{"title": "なし", "body": "なし"}]  # type: ignore[assignment]
+
+    parts: list[str] = []
+    for lesson in lessons:
+        title = html.escape(getattr(lesson, "title", "なし"))
+        body = html.escape(getattr(lesson, "body", "なし"))
+        body_html = f'  <p class="exp">{body}</p>'
+        if title == "なし" and body == "なし":
+            body_html = ""
+        parts.append(
+            "\n".join(
+                [
+                    '<div class="termCard deepDiveCard">',
+                    f'  <div class="term">{title}</div>',
+                    body_html,
                     "</div>",
                 ]
             )
@@ -151,6 +176,7 @@ def write_article_html(
         # summary_htmlは既にサニタイズ済み前提（属性禁止/許可タグのみ）
         "summary_html": item.analysis.summary_html,
         "technical_terms_html": _term_cards_html(item),
+        "deep_dive_html": _lesson_cards_html(item),
         "window_from_jst": html.escape(window_from_jst),
         "window_to_jst": html.escape(window_to_jst),
         "generated_at_jst": html.escape(generated_at_jst),

--- a/src/notifyhub_digest/templates/article.html
+++ b/src/notifyhub_digest/templates/article.html
@@ -183,6 +183,22 @@
       font-size:12px;
       white-space:pre-wrap;
     }
+    .subSectionTitle{
+      margin:16px 0 8px;
+      font-size:12px;
+      letter-spacing:.08em;
+      text-transform:uppercase;
+      color:var(--muted);
+    }
+    .deepDive{
+      display:grid;
+      grid-template-columns: 1fr;
+      gap:10px;
+      margin-top:8px;
+    }
+    .deepDiveCard{
+      background:rgba(12,20,38,.6);
+    }
 
     .footer{
       margin-top:14px;
@@ -251,6 +267,10 @@
           <h2>📌 キーワード解説</h2>
           <div class="terms">
             {{technical_terms_html}}
+          </div>
+          <h3 class="subSectionTitle">深掘り解説</h3>
+          <div class="deepDive">
+            {{deep_dive_html}}
           </div>
         </div>
 

--- a/tests/test_openai_analysis_result.py
+++ b/tests/test_openai_analysis_result.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from notifyhub_digest.openai_client import _coerce_analysis_result
+
+
+def test_coerce_analysis_result_accepts_lesson_payload() -> None:
+    result = _coerce_analysis_result(
+        {
+            "summary_html": "<h4>概要</h4><p>summary</p>",
+            "technical_terms": [{"term": "mTLS", "explanation": "相互認証。"}],
+            "lessons": [{"title": "公開鍵認証", "body": "TLSでは証明書検証で相手を確認する。例えば社内PKIでも同じ考え方を使う。"}],
+            "impact_level": "High",
+            "impact_reason": "reason",
+            "threat_type": "Vulnerability",
+        }
+    )
+
+    assert len(result.lessons) == 1
+    assert result.lessons[0].title == "公開鍵認証"
+    assert "TLS" in result.lessons[0].body
+
+
+def test_coerce_analysis_result_missing_lessons_defaults_empty() -> None:
+    result = _coerce_analysis_result(
+        {
+            "summary_html": "<h4>概要</h4><p>summary</p>",
+            "technical_terms": [],
+            "impact_level": "Low",
+            "impact_reason": "reason",
+            "threat_type": "Patch",
+        }
+    )
+
+    assert result.lessons == []
+
+
+def test_coerce_analysis_result_ignores_removed_read_action_fields() -> None:
+    result = _coerce_analysis_result(
+        {
+            "summary_html": "<h4>概要</h4><p>summary</p>",
+            "technical_terms": [],
+            "lessons": [{"title": "なし", "body": "なし"}],
+            "impact_level": "Medium",
+            "impact_reason": "reason",
+            "threat_type": "Advisory",
+            "read_action": "Read",
+            "action_reason": "unused",
+        }
+    )
+
+    assert result.impact_level == "Medium"
+    assert result.lessons[0].title == "なし"

--- a/tests/test_render_deep_dive.py
+++ b/tests/test_render_deep_dive.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from notifyhub_digest.models import AnalysisResult, FeedItem, Lesson
+from notifyhub_digest.render import write_article_html
+from notifyhub_digest.timeutils import JST
+
+
+def _feed_item(*, lessons: list[Lesson]) -> FeedItem:
+    return FeedItem(
+        entry_id="entry-1",
+        title="Sample Title",
+        source_name="Sample Source",
+        category="reporting",
+        published_at=datetime(2026, 4, 24, 9, 0, tzinfo=JST),
+        original_url="https://example.com/article",
+        analysis=AnalysisResult(
+            summary_html="<h4>概要</h4><p>summary</p>",
+            technical_terms=[],
+            lessons=lessons,
+            impact_level="High",
+            impact_reason="important reason",
+            threat_type="Vulnerability",
+        ),
+    )
+
+
+def test_write_article_html_renders_deep_dive(tmp_path) -> None:
+    template_path = tmp_path / "article.html"
+    output_dir = tmp_path / "out"
+    template_path.write_text(
+        "<html><body><section>{{technical_terms_html}}</section><section>{{deep_dive_html}}</section></body></html>",
+        encoding="utf-8",
+    )
+
+    item: FeedItem = _feed_item(lessons=[Lesson(title="HTTPS証明書", body="例えばブラウザは証明書チェーンをたどって正当性を確認する。")])
+    write_article_html(
+        template_path,
+        output_dir,
+        item,
+        window_from_jst="2026-04-24T00:00:00+09:00",
+        window_to_jst="2026-04-25T00:00:00+09:00",
+        generated_at_jst="2026-04-24T08:00:00+09:00",
+        digest_root_url="https://notifyhub.site/digest/2026/04/24/",
+    )
+
+    content = (output_dir / "articles" / "entry-1.html").read_text(encoding="utf-8")
+    assert "HTTPS証明書" in content
+    assert "深掘り解説" not in content
+
+
+def test_write_article_html_renders_none_when_lessons_empty(tmp_path) -> None:
+    template_path = tmp_path / "article.html"
+    output_dir = tmp_path / "out"
+    template_path.write_text("<html><body>{{deep_dive_html}}</body></html>", encoding="utf-8")
+
+    item: FeedItem = _feed_item(lessons=[])
+    write_article_html(
+        template_path,
+        output_dir,
+        item,
+        window_from_jst="2026-04-24T00:00:00+09:00",
+        window_to_jst="2026-04-25T00:00:00+09:00",
+        generated_at_jst="2026-04-24T08:00:00+09:00",
+        digest_root_url="https://notifyhub.site/digest/2026/04/24/",
+    )
+
+    content = (output_dir / "articles" / "entry-1.html").read_text(encoding="utf-8")
+    assert "なし" in content
+    assert content.count("なし") == 1


### PR DESCRIPTION
## Summary
- digest 記事に「深掘り解説」セクションを追加
- OpenAI の分析スキーマとレンダリングを更新し、不要になった判断/対応アクション出力を削除
- Python 3.11 の `.venv` を使うためのワークスペース設定と README を更新

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_openai_analysis_result.py tests/test_render_deep_dive.py