### PR TITLE
Show model version in analysis heading

### DIFF
--- a/src/notifyhub_digest/models.py
+++ b/src/notifyhub_digest/models.py
@@ -69,6 +69,7 @@ class AnalysisResult(BaseModel):
     impact_level: ImpactLevel = "Unknown"
     impact_reason: str = ""
     threat_type: ThreatType = "Unknown"
+    model_version: str = ""
 
 
 class FeedItem(BaseModel):

--- a/src/notifyhub_digest/openai_client.py
+++ b/src/notifyhub_digest/openai_client.py
@@ -210,6 +210,15 @@ def _extract_response_text(data: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_response_model(data: dict[str, Any]) -> str:
+    if not isinstance(data, dict):
+        return ""
+    model = data.get("model")
+    if isinstance(model, str):
+        return model.strip()
+    return ""
+
+
 def _extract_json_object(text: str) -> dict[str, Any]:
     """Extract a JSON object from model output.
 
@@ -406,6 +415,7 @@ def _coerce_analysis_result(parsed: dict[str, Any]) -> AnalysisResult:
             impact_level=str(parsed.get("impact_level") or "Unknown"),
             impact_reason=str(parsed.get("impact_reason") or ""),
             threat_type=_normalize_threat_type(str(parsed.get("threat_type") or "")),
+            model_version=str(parsed.get("model_version") or ""),
         )
 
 
@@ -496,12 +506,14 @@ def analyze_item(
 
     data = res.json()
     content = _extract_response_text(data)
+    model_version = _extract_response_model(data) or cfg.model
 
     try:
         parsed = _extract_json_object(content)
         result = _coerce_analysis_result(parsed)
         if not result.summary_html:
             result.summary_html = _fallback_summary_html(summary)
+        result.model_version = model_version
         return result
     except Exception as e:
         if content.strip():
@@ -515,4 +527,5 @@ def analyze_item(
             impact_level="Unknown",
             impact_reason="",
             threat_type="Unknown",
+            model_version=model_version,
         )

--- a/src/notifyhub_digest/render.py
+++ b/src/notifyhub_digest/render.py
@@ -88,6 +88,13 @@ def _lesson_cards_html(item: FeedItem) -> str:
     return "\n".join(parts)
 
 
+def _analysis_heading(item: FeedItem) -> str:
+    model_version = (item.analysis.model_version or "").strip()
+    if not model_version:
+        return "要約（ChatGPT）"
+    return f"要約（ChatGPT / {html.escape(model_version)}）"
+
+
 @dataclass(frozen=True)
 class DigestPaths:
     digest_dir: Path
@@ -173,6 +180,7 @@ def write_article_html(
         "impact_level": html.escape(item.analysis.impact_level),
         "impact_reason": html.escape(item.analysis.impact_reason),
         "threat_type": html.escape(item.analysis.threat_type),
+        "analysis_heading": _analysis_heading(item),
         # summary_htmlは既にサニタイズ済み前提（属性禁止/許可タグのみ）
         "summary_html": item.analysis.summary_html,
         "technical_terms_html": _term_cards_html(item),

--- a/src/notifyhub_digest/templates/article.html
+++ b/src/notifyhub_digest/templates/article.html
@@ -258,7 +258,7 @@
           <div class="ruleReason">{{impact_reason}}</div>
         </div>
         <div class="section summary">
-          <h2>🧾 要約（ChatGPT）</h2>
+          <h2>🧾 {{analysis_heading}}</h2>
           <!-- 注意：summary_html は「許可タグのみ」にサーバ側でバリデーションしてから埋め込む想定 -->
           {{summary_html}}
         </div>

--- a/tests/test_render_deep_dive.py
+++ b/tests/test_render_deep_dive.py
@@ -22,6 +22,7 @@ def _feed_item(*, lessons: list[Lesson]) -> FeedItem:
             impact_level="High",
             impact_reason="important reason",
             threat_type="Vulnerability",
+            model_version="gpt-5.4-2026-04-20",
         ),
     )
 
@@ -69,3 +70,23 @@ def test_write_article_html_renders_none_when_lessons_empty(tmp_path) -> None:
     content = (output_dir / "articles" / "entry-1.html").read_text(encoding="utf-8")
     assert "なし" in content
     assert content.count("なし") == 1
+
+
+def test_write_article_html_renders_model_version_in_summary_heading(tmp_path) -> None:
+    template_path = tmp_path / "article.html"
+    output_dir = tmp_path / "out"
+    template_path.write_text("<html><body><h2>{{analysis_heading}}</h2>{{summary_html}}</body></html>", encoding="utf-8")
+
+    item: FeedItem = _feed_item(lessons=[])
+    write_article_html(
+        template_path,
+        output_dir,
+        item,
+        window_from_jst="2026-04-24T00:00:00+09:00",
+        window_to_jst="2026-04-25T00:00:00+09:00",
+        generated_at_jst="2026-04-24T08:00:00+09:00",
+        digest_root_url="https://notifyhub.site/digest/2026/04/24/",
+    )
+
+    content = (output_dir / "articles" / "entry-1.html").read_text(encoding="utf-8")
+    assert "要約（ChatGPT / gpt-5.4-2026-04-20）" in content


### PR DESCRIPTION
## Summary
- capture the model version returned by the OpenAI Responses API and store it on the analysis result
- render the model version in the article summary heading when it is available
- add rendering coverage for the summary heading in the deep-dive article tests

## Testing
- .venv\\Scripts\\python.exe -m pytest tests/test_openai_analysis_result.py tests/test_openai_parse.py tests/test_render_deep_dive.py