### PR TITLE
Fix Azure CLI container create argument

### DIFF
--- a/.github/workflows/digest-generate.yml
+++ b/.github/workflows/digest-generate.yml
@@ -218,8 +218,7 @@ jobs:
             az storage container create \
               --account-name "${{ secrets.AZURE_STORAGE_ACCOUNT }}" \
               --account-key "${{ secrets.AZURE_STORAGE_KEY }}" \
-              --name "$container" \
-              --fail-on-exist false 1>/dev/null
+              --name "$container" 1>/dev/null
 
             mode="${WORKFLOW_BACKUP_MODE:-auto}"
             if [[ -z "$mode" || "$mode" == "auto" ]]; then


### PR DESCRIPTION
## Summary
- remove the invalid value passed to az storage container create
- fix the backup mode step so the workflow can proceed to Blob backup, cleanup, and SWA deploy

## Cause
- the previous PR was merged before this follow-up fix commit was added
- main still contains --fail-on-exist false in digest-generate.yml

## Testing
- inspected failing Actions log showing: ERROR: unrecognized arguments: false