### PR TITLE
Add max-items option for manual digest runs

### DIFF
--- a/.github/workflows/digest-generate.yml
+++ b/.github/workflows/digest-generate.yml
@@ -292,6 +292,7 @@ jobs:
       - name: Generate Pagefind index
         run: |
           set -euo pipefail
+          rm -rf site/pagefind
           npx --yes pagefind --site site --output-path site/pagefind
 
       - name: Upload artifact (generated digest)

--- a/.github/workflows/digest-generate.yml
+++ b/.github/workflows/digest-generate.yml
@@ -20,6 +20,10 @@ on:
           - "auto"
           - "full"
           - "daily"
+      max_items:
+        description: "Optional max digest items to process (0 = skip item processing)"
+        required: false
+        default: ""
   schedule:
     # JST 06:05 == UTC 21:05 (previous day)
     - cron: "5 21 * * *"
@@ -201,9 +205,22 @@ jobs:
             EMAIL_FLAG="--send-email"
           fi
 
+          MAX_ITEMS_FLAG=""
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MAX_ITEMS_INPUT="${{ inputs.max_items }}"
+            if [[ -n "$MAX_ITEMS_INPUT" ]]; then
+              if [[ ! "$MAX_ITEMS_INPUT" =~ ^[0-9]+$ ]]; then
+                echo "max_items must be an integer >= 0" >&2
+                exit 1
+              fi
+              MAX_ITEMS_FLAG="--max-items $MAX_ITEMS_INPUT"
+            fi
+          fi
+
           notifyhub-digest run \
             --out-dir site \
             --run-at "$RUN_AT" \
+            $MAX_ITEMS_FLAG \
             $EMAIL_FLAG
 
       - name: Determine backup mode

--- a/README.md
+++ b/README.md
@@ -203,11 +203,19 @@ GitHub Actions のスケジュール実行で日次生成し、`site/` 配下に
 
 Blob Storage への接続は GitHub Secrets の `AZURE_STORAGE_ACCOUNT` と `AZURE_STORAGE_KEY` を使います。
 
-`workflow_dispatch` では `backup_mode` を `auto` / `full` / `daily` から選べます。
+`workflow_dispatch` では `backup_mode` を `auto` / `full` / `daily` から選べます。あわせて `max_items` を指定すると、手動実行の `digest-generate` で処理するダイジェスト件数の上限を絞れます。テスト目的の実行を短くしたいときに使います。
 
 - `auto` : Blob Storage の `full/` 配下に既存バックアップがあるかを見て自動判定します。初回実行などで `full/` が空なら `full` と同じ動きになり、すでに full backup があれば `daily` と同じ動きになります。
 - `full` : その日の digest だけではなく、保持期間内に残っている `site/digest/` 配下の全日分をまとめて `full/` 配下へ保存します。大きめの再取得を明示的に取りたいとき向けです。
 - `daily` : 当日分の `site/digest/YYYY/MM/DD/` と、参照に必要な `site/index.html`、`site/digest/index.html`、`site/digest/latest/index.html` を `daily/YYYY-MM-DD/` 配下へ保存します。通常の日次運用向けです。
+
+`max_items` の挙動:
+
+- 空欄: 従来どおり全件処理します。
+- `0`: 記事処理をスキップします。取得・解析を走らせずに workflow や deploy の疎通確認だけしたいとき向けです。
+- `1` 以上の自然数: その件数に達した時点で、以後の取得と解析を打ち切ります。手動テストで待ち時間を短くしたいとき向けです。
+
+つまり、`max_items` は手動実行時のテスト高速化用の入力です。普段どおり全件を処理したい場合は空欄のまま実行してください。
 
 重要なのは順序です。workflow は先に Blob Storage への通常バックアップを完了させ、そのあとで古い digest を削除します。したがって backup が失敗した場合、cleanup は実行されません。追加の一時退避先や `retention/...` のような別枠は使いません。
 

--- a/src/notifyhub_digest/cli.py
+++ b/src/notifyhub_digest/cli.py
@@ -94,6 +94,12 @@ def run(
         "--send-email/--no-send-email",
         help="任意: ACS Emailで送信する（要: pip install '.[acs]' と環境変数ACS_EMAIL_*）",
     ),
+    max_items: int | None = typer.Option(
+        None,
+        "--max-items",
+        min=0,
+        help="任意: 処理するダイジェスト件数の上限。0 を指定すると記事処理をスキップ",
+    ),
 ):
     """日次レポートを生成します（ローカル実行版）。"""
 
@@ -105,6 +111,7 @@ def run(
         sources_path=sources_path,
         run_at_iso=run_at_iso,
         send_email=send_email,
+        max_items=max_items,
     )
 
 

--- a/src/notifyhub_digest/runner.py
+++ b/src/notifyhub_digest/runner.py
@@ -72,6 +72,7 @@ def build_digest_outputs(
     out_dir: Path,
     sources_path: Path,
     run_at_iso: str | None,
+    max_items: int | None = None,
 ) -> BuiltDigest:
     """Generate digest outputs (index/articles/manifest) and return in-memory context."""
 
@@ -89,56 +90,66 @@ def build_digest_outputs(
     grok_cfg = load_grok_config()
     featured_settings = load_featured_topics_settings()
 
+    if max_items is not None and max_items < 0:
+        raise ValueError("max_items must be >= 0")
+
     items: list[FeedItem] = []
     featured_topics: list[FeaturedTopic] = []
 
     transport = httpx.HTTPTransport(retries=retries)
     with httpx.Client(timeout=timeout, follow_redirects=True, transport=transport) as client:
-        for src in enabled:
-            try:
-                entries = fetch_feed_entries(client, src, user_agent=user_agent)
-            except Exception as e:
-                logger.warning("Fetch failed: %s (%s)", src.name, e)
-                continue
+        if max_items != 0:
+            for src in enabled:
+                if max_items is not None and len(items) >= max_items:
+                    break
 
-            for e in entries:
-                if not (window.start_utc <= e.published_at_utc < window.end_utc):
+                try:
+                    entries = fetch_feed_entries(client, src, user_agent=user_agent)
+                except Exception as e:
+                    logger.warning("Fetch failed: %s (%s)", src.name, e)
                     continue
 
-                analysis = AnalysisResult(summary_html="", technical_terms=[], impact_level="Unknown", threat_type="Unknown")
-                if openai_cfg is not None:
-                    try:
-                        analysis = analyze_item(
-                            client,
-                            openai_cfg,
-                            title=e.title,
-                            source_name=src.name,
-                            published_at_iso=e.published_at_utc.isoformat(),
-                            original_url=e.link,
-                            summary=e.summary,
-                        )
-                    except Exception as ai_e:
-                        logger.warning("OpenAI analysis failed: %s (%s)", e.entry_id, ai_e)
-                        analysis = AnalysisResult(
-                            summary_html="", technical_terms=[], impact_level="Unknown", threat_type="Unknown"
-                        )
+                for e in entries:
+                    if max_items is not None and len(items) >= max_items:
+                        break
 
-                # summary_htmlは必ずサニタイズ（仕様必須）
-                analysis.summary_html = sanitize_summary_html(analysis.summary_html)
+                    if not (window.start_utc <= e.published_at_utc < window.end_utc):
+                        continue
 
-                item = FeedItem(
-                    entry_id=e.entry_id,
-                    title=e.title,
-                    source_name=src.name,
-                    category=src.category,
-                    published_at=e.published_at_utc,
-                    original_url=e.link,
-                    analysis=analysis,
-                )
+                    analysis = AnalysisResult(summary_html="", technical_terms=[], impact_level="Unknown", threat_type="Unknown")
+                    if openai_cfg is not None:
+                        try:
+                            analysis = analyze_item(
+                                client,
+                                openai_cfg,
+                                title=e.title,
+                                source_name=src.name,
+                                published_at_iso=e.published_at_utc.isoformat(),
+                                original_url=e.link,
+                                summary=e.summary,
+                            )
+                        except Exception as ai_e:
+                            logger.warning("OpenAI analysis failed: %s (%s)", e.entry_id, ai_e)
+                            analysis = AnalysisResult(
+                                summary_html="", technical_terms=[], impact_level="Unknown", threat_type="Unknown"
+                            )
 
-                items.append(item)
+                    # summary_htmlは必ずサニタイズ（仕様必須）
+                    analysis.summary_html = sanitize_summary_html(analysis.summary_html)
 
-        if grok_cfg is not None and featured_settings.count > 0:
+                    item = FeedItem(
+                        entry_id=e.entry_id,
+                        title=e.title,
+                        source_name=src.name,
+                        category=src.category,
+                        published_at=e.published_at_utc,
+                        original_url=e.link,
+                        analysis=analysis,
+                    )
+
+                    items.append(item)
+
+        if max_items != 0 and grok_cfg is not None and featured_settings.count > 0:
             try:
                 featured_topics = build_featured_topics(
                     client,
@@ -233,8 +244,14 @@ def run_digest(
     sources_path: Path,
     run_at_iso: str | None,
     send_email: bool = False,
+    max_items: int | None = None,
 ) -> None:
-    built = build_digest_outputs(out_dir=out_dir, sources_path=sources_path, run_at_iso=run_at_iso)
+    built = build_digest_outputs(
+        out_dir=out_dir,
+        sources_path=sources_path,
+        run_at_iso=run_at_iso,
+        max_items=max_items,
+    )
 
     # Email送信（有効時は送信成功時のみ既読更新）
     if should_send_email(send_email):

--- a/tests/test_featured_topic.py
+++ b/tests/test_featured_topic.py
@@ -146,6 +146,82 @@ def test_build_digest_outputs_ignores_featured_topic_failures(tmp_path: Path, mo
     assert (tmp_path / "out" / "digest" / "2026" / "01" / "12" / "manifest.json").exists()
 
 
+def test_build_digest_outputs_respects_max_items_and_stops_early(tmp_path: Path, monkeypatch) -> None:
+    run_at_iso = "2026-01-12T06:00:00+09:00"
+    window = compute_daily_window(datetime.fromisoformat(run_at_iso))
+
+    first = Source(name="First", feed_url="https://example.com/first", enabled=True)
+    second = Source(name="Second", feed_url="https://example.com/second", enabled=True)
+    monkeypatch.setattr("notifyhub_digest.runner.load_sources", lambda _p: [first, second])
+    monkeypatch.setattr("notifyhub_digest.runner.iter_enabled_sources", lambda sources: list(sources))
+
+    fetch_calls: list[str] = []
+
+    def _fetch(_client, src, user_agent):
+        fetch_calls.append(src.name)
+        return [
+            RawEntry(
+                entry_id=f"{src.name}-1",
+                title=f"{src.name} Title",
+                link=f"https://example.com/{src.name.lower()}",
+                published_at_utc=window.start_utc + timedelta(minutes=1),
+                summary="summary",
+            )
+        ]
+
+    monkeypatch.setattr("notifyhub_digest.runner.fetch_feed_entries", _fetch)
+    monkeypatch.setattr("notifyhub_digest.runner.load_grok_config", lambda: None)
+
+    built = build_digest_outputs(
+        out_dir=tmp_path / "out",
+        sources_path=tmp_path / "sources.json",
+        run_at_iso=run_at_iso,
+        max_items=1,
+    )
+
+    assert len(built.items) == 1
+    assert built.items[0].entry_id == "First-1"
+    assert fetch_calls == ["First"]
+
+
+def test_build_digest_outputs_skips_items_and_featured_topics_when_max_items_zero(tmp_path: Path, monkeypatch) -> None:
+    run_at_iso = "2026-01-12T06:00:00+09:00"
+    src = Source(name="Digest Source", feed_url="https://example.com/feed", enabled=True)
+    monkeypatch.setattr("notifyhub_digest.runner.load_sources", lambda _p: [src])
+    monkeypatch.setattr("notifyhub_digest.runner.iter_enabled_sources", lambda sources: list(sources))
+
+    fetch_calls: list[str] = []
+    featured_calls: list[bool] = []
+
+    monkeypatch.setattr(
+        "notifyhub_digest.runner.fetch_feed_entries",
+        lambda _client, _src, user_agent: fetch_calls.append("called") or [],
+    )
+    monkeypatch.setattr("notifyhub_digest.runner.load_grok_config", lambda: object())
+
+    class _Settings:
+        count = 2
+        categories = ["Advisory", "Ransomware"]
+
+    monkeypatch.setattr("notifyhub_digest.runner.load_featured_topics_settings", lambda: _Settings())
+    monkeypatch.setattr(
+        "notifyhub_digest.runner.build_featured_topics",
+        lambda *args, **kwargs: featured_calls.append(True) or [],
+    )
+
+    built = build_digest_outputs(
+        out_dir=tmp_path / "out",
+        sources_path=tmp_path / "sources.json",
+        run_at_iso=run_at_iso,
+        max_items=0,
+    )
+
+    assert built.items == []
+    assert built.featured_topics == []
+    assert fetch_calls == []
+    assert featured_calls == []
+
+
 def test_build_user_prompt_adds_generic_tech_trend_guidance() -> None:
     class _Settings:
         count = 3


### PR DESCRIPTION
## Summary
- add a max_items workflow_dispatch input for digest-generate
- pass the limit through the CLI into the digest runner
- stop fetching and analyzing once the requested number of items has been processed
- document the manual test behavior in the README

## Behavior
- blank: process all items as before
- 0: skip item processing for quick workflow and deploy verification
- 1 or more: stop processing once that many items have been handled

## Testing
- PYTHONPATH=src pytest tests/test_featured_topic.py tests/test_runner_email_gate.py -q